### PR TITLE
fix(Focus): Highlight focused game object in list view on double click - BUS-81

### DIFF
--- a/Assembus/Assets/Scenes/MainScene.unity
+++ b/Assembus/Assets/Scenes/MainScene.unity
@@ -6288,6 +6288,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   componentHighlighting: {fileID: 963194230}
+  hierarchyViewController: {fileID: 2006810628}
   doubleClickDetector: {fileID: 963194231}
 --- !u!114 &963194230
 MonoBehaviour:
@@ -7714,8 +7715,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 665188724}
   m_HandleRect: {fileID: 665188723}
   m_Direction: 0
-  m_Value: -0.0000038146827
-  m_Size: 0.97476333
+  m_Value: 0.000011444092
+  m_Size: 0.9747634
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assembus/Assets/Scripts/MainScreen/CameraController.cs
+++ b/Assembus/Assets/Scripts/MainScreen/CameraController.cs
@@ -1,4 +1,5 @@
-﻿using Services;
+﻿using MainScreen.Sidebar.HierarchyView;
+using Services;
 using UnityEngine;
 
 namespace MainScreen
@@ -20,6 +21,11 @@ namespace MainScreen
         ///     Reference to highlighting script
         /// </summary>
         public ComponentHighlighting componentHighlighting;
+
+        /// <summary>
+        ///     Reference to the hierarchy view controller
+        /// </summary>
+        public HierarchyViewController hierarchyViewController;
 
         /// <summary>
         ///     The click detector instance
@@ -149,6 +155,7 @@ namespace MainScreen
             if (!MouseOverViewport) return;
 
             componentHighlighting.HighlightGameObject(o);
+            hierarchyViewController.SetItemStatusFromList(new[] {o.name});
             SetFocus(transformGameObject);
             StoreLastMousePosition();
             CalculateNewCameraTransform();


### PR DESCRIPTION
On double clicking to focus an object in the 3d view, the focused game object is now being highlighted
in the list-view instead of being deselected.