### PR TITLE
feature/list-hover-highlight-BUS-89

### DIFF
--- a/Assembus/Assets/Scenes/MainScene.unity
+++ b/Assembus/Assets/Scenes/MainScene.unity
@@ -1998,6 +1998,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6e4903f57d35ecc45b83f992387e38dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  componentHighlighting: {fileID: 963194230}
   highlightedColor: {r: 0.30588236, g: 0.3882353, b: 0.50980395, a: 1}
   normalColor: {r: 0.20784314, g: 0.28627452, b: 0.40392157, a: 1}
   hierarchyViewController: {fileID: 2006810628}
@@ -9593,8 +9594,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 665188724}
   m_HandleRect: {fileID: 665188723}
   m_Direction: 0
-  m_Value: -0.0000038146973
-  m_Size: 0.97476333
+  m_Value: -0.000011444135
+  m_Size: 0.9747635
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assembus/Assets/Scripts/MainScreen/ComponentHighlighting.cs
+++ b/Assembus/Assets/Scripts/MainScreen/ComponentHighlighting.cs
@@ -293,6 +293,27 @@ namespace MainScreen
         }
 
         /// <summary>
+        ///     Highlights a given game object with the hovering color, used
+        ///     to indicate which object is hovered over in the item list-view
+        /// </summary>
+        /// <param name="gO">Game object to be highlighted</param>
+        public void HighlightHoverFromList(GameObject gO)
+        {
+            // Check if component has a Renderer
+            if (gO.GetComponent<Renderer>() != null)
+            {
+                HighlightHover(gO);
+            }
+            else
+            {
+                if (_hoveredObject == null) return;
+
+                _hoveredObject.GetComponent<Renderer>().material.color = _hoveredOriginalColor;
+                _hoveredObject = null;
+            }
+        }
+
+        /// <summary>
         ///     Reset highlighting, when application is closed
         /// </summary>
         public void ResetHighlighting()

--- a/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyItemController.cs
+++ b/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyItemController.cs
@@ -728,10 +728,12 @@ namespace MainScreen.Sidebar.HierarchyView
             var selected = hierarchyViewController.IsSelected(this);
             background.color = Dragging && !selected ? normalColor : highlightedColor;
 
-
             // Show the moving indicator
             movingIndicator.SetActive(Dragging && !selected);
 
+            // Highlight hovered object
+            HighlightHover();
+            
             // Save the item and the action
             _insertion = false;
             _dragItem = selected ? null : this;
@@ -761,9 +763,7 @@ namespace MainScreen.Sidebar.HierarchyView
             background.color = Dragging && !isGroup && !selected ? normalColor : highlightedColor;
 
             // Highlight hovered object
-            var parent = _projectManager.CurrentProject.ObjectModel.transform;
-            var hoveredObject = Utility.FindChild(parent, name).gameObject;
-            componentHighlighting.HighlightHoverFromList(hoveredObject);
+            HighlightHover();
 
             // Save the item and the action if item is compatible
             _insertion = true;
@@ -778,6 +778,16 @@ namespace MainScreen.Sidebar.HierarchyView
         {
             _dragItem = null;
             if (!hierarchyViewController.IsSelected(this)) background.color = normalColor;
+        }
+
+        /// <summary>
+        ///     Highlights currently hovered items in the editor
+        /// </summary>
+        private void HighlightHover()
+        {
+            var parent = _projectManager.CurrentProject.ObjectModel.transform;
+            var hoveredObject = Utility.FindChild(parent, name).gameObject;
+            componentHighlighting.HighlightHoverFromList(hoveredObject);
         }
 
         /// <summary>

--- a/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyItemController.cs
+++ b/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyItemController.cs
@@ -42,6 +42,11 @@ namespace MainScreen.Sidebar.HierarchyView
         private static List<HierarchyItemController> _selectedItems = new List<HierarchyItemController>();
 
         /// <summary>
+        ///     Reference to ComponentHighlighting script
+        /// </summary>
+        public ComponentHighlighting componentHighlighting;
+
+        /// <summary>
         ///     The colors for the item
         /// </summary>
         public Color highlightedColor, normalColor;
@@ -754,6 +759,11 @@ namespace MainScreen.Sidebar.HierarchyView
             var isGroup = itemInfo.ItemInfo.isGroup;
             var selected = hierarchyViewController.IsSelected(this);
             background.color = Dragging && !isGroup && !selected ? normalColor : highlightedColor;
+
+            // Highlight hovered object
+            var parent = _projectManager.CurrentProject.ObjectModel.transform;
+            var hoveredObject = Utility.FindChild(parent, name).gameObject;
+            componentHighlighting.HighlightHoverFromList(hoveredObject);
 
             // Save the item and the action if item is compatible
             _insertion = true;

--- a/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyViewController.cs
+++ b/Assembus/Assets/Scripts/MainScreen/Sidebar/HierarchyView/HierarchyViewController.cs
@@ -435,9 +435,9 @@ namespace MainScreen.Sidebar.HierarchyView
         }
 
         /// <summary>
-        ///     Return the selected GameObjects as a list in the right order
+        ///     Return the selected game objects as a list in the right order
         /// </summary>
-        /// <returns></returns>
+        /// <returns>List of selected game objects</returns>
         public List<HierarchyItemController> GetSelectedItems()
         {
             return SelectedItems.OrderByDescending(item => item.itemContent.position.y).ToList();


### PR DESCRIPTION
Game objects are now highlighted in the 3d editor, when hovering over them in the list view, or when hovering over them while dragging an item.